### PR TITLE
Instructions for developing on Cloud 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you're developing on [Cloud 9](https://c9.io/) you'll need to create a custom
 
 1. Go to Run->Run With->New Runner
 2. Replace the default runner text with the following:
-
+```
     {
         "cmd" : [
             "bash",
@@ -34,9 +34,9 @@ If you're developing on [Cloud 9](https://c9.io/) you'll need to create a custom
             "cd $project_path ; mkdocs serve --dev-addr=$ip:$port"],
         "info" : "Started mkdocs server"
     }
-        
+```        
 3. Save the new runner
 4. Start the runner as follows:
-    a. Go to Run->Run With->(your new runner)
-    b. After your runner starts, click Preview->Preview Running Application (above the editor)
+  1. Go to Run->Run With->(your new runner)
+  2. After your runner starts, click Preview->Preview Running Application (above the editor)
 

--- a/README.md
+++ b/README.md
@@ -19,3 +19,24 @@ You will need to have python, pip and virtualenv installed (install virtualenv u
 
 ## Running
     mkdocs serve
+
+## Running on Cloud 9
+If you're developing on [Cloud 9](https://c9.io/) you'll need to create a custom runner for mkdocs as follows:
+
+1. Go to Run->Run With->New Runner
+2. Replace the default runner text with the following:
+
+    {
+        "cmd" : [
+            "bash",
+            "--login",
+            "-c",
+            "cd $project_path ; mkdocs serve --dev-addr=$ip:$port"],
+        "info" : "Started mkdocs server"
+    }
+        
+3. Save the new runner
+4. Start the runner as follows:
+    a. Go to Run->Run With->(your new runner)
+    b. After your runner starts, click Preview->Preview Running Application (above the editor)
+


### PR DESCRIPTION
Minor change to README with instructions on running mkdocs under Cloud 9.  A bit specialized, but since the first workspace on Cloud 9 is free I find it very convenient to contribute to the community docs this way.  Not at all offended if you feel this is too specialized to include.
