### PR TITLE
Char marketorders correction

### DIFF
--- a/docs/xmlapi/char_marketorders.md
+++ b/docs/xmlapi/char_marketorders.md
@@ -24,7 +24,7 @@
             <tr>
                 <td>characterID</td>
                 <td><strong>long</strong></td>
-                <td>ID of character. Optional if the key is character specific.</td>
+                <td>ID of character. Optional only if the key is character specific, otherwise mandatory.</td>
             </tr>
             <tr>
                 <td>orderID</td>

--- a/docs/xmlapi/char_marketorders.md
+++ b/docs/xmlapi/char_marketorders.md
@@ -24,7 +24,7 @@
             <tr>
                 <td>characterID</td>
                 <td><strong>long</strong></td>
-                <td>ID of character</td>
+                <td>ID of character. Optional if the key is character specific.</td>
             </tr>
             <tr>
                 <td>orderID</td>

--- a/docs/xmlapi/char_marketorders.md
+++ b/docs/xmlapi/char_marketorders.md
@@ -22,6 +22,11 @@
                 <td>API verification code</td>
             </tr>
             <tr>
+                <td>characterID</td>
+                <td><strong>long</strong></td>
+                <td>ID of character</td>
+            </tr>
+            <tr>
                 <td>orderID</td>
                 <td><strong>long</strong></td>
                 <td>Optional order ID of order to retrieve.  If omitted, retrieves an order batch (see notes).</td>


### PR DESCRIPTION
Added the parameter characterID to /Char/MarketOrders. Parameter is optional for character specific keys, but mandatory otherwise.