### PR TITLE
Replaced the unicode asterisk character with descriptive text for foo…

### DIFF
--- a/docs/xmlapi/character/char_mailbodies.md
+++ b/docs/xmlapi/character/char_mailbodies.md
@@ -3,7 +3,7 @@ Returns the bodies of eve mail messages sent to the character.
 
 * __Path:__ ``/char/MailBodies.xml.aspx``
 * __Access mask:__ 512
-* __Cache timer:__ 10 years - see notes below
+* __Cache timer:__ 10 years <sup style="color: red; font-weight: bold">(see notes below)</sup>
 * __Parameters:__
     <table border="1">
         <tbody>

--- a/docs/xmlapi/character/char_notificationtexts.md
+++ b/docs/xmlapi/character/char_notificationtexts.md
@@ -3,7 +3,7 @@ Retrieve character notification bodies.
 
 * __Path:__ ``/char/NotificationTexts.xml.aspx``
 * __Access mask:__ 32768
-* __Cache timer:__ 10 years - see notes below
+* __Cache timer:__ 10 years <sup style="color: red; font-weight: bold">(see notes below)</sup>
 * __Parameters:__
     <table border="1">
         <tbody>

--- a/docs/xmlapi/character/char_planetarycolonies.md
+++ b/docs/xmlapi/character/char_planetarycolonies.md
@@ -3,7 +3,7 @@ Retrieve planetary colonies owned by character.
 
 * __Path:__ ``/char/PlanetaryColonies.xml.aspx``
 * __Access mask:__ 2
-* __Cache timer:__ 60 minutes <sup title="Planetary colony information has special update rules.  See notes below" style="color: red">&#x2605;</sup>
+* __Cache timer:__ 60 minutes <sup style="color: red; font-weight: bold">(see notes below)</sup>
 * __Parameters:__
     <table border="1">
         <tbody>

--- a/docs/xmlapi/character/char_planetarylinks.md
+++ b/docs/xmlapi/character/char_planetarylinks.md
@@ -3,7 +3,7 @@ Retrieve planetary links for colonies owned by character.
 
 * __Path:__ ``/char/PlanetaryLinks.xml.aspx``
 * __Access mask:__ 2
-* __Cache timer:__ 60 minutes <sup title="Planetary colony information has special update rules.  See notes below" style="color: red">&#x2605;</sup>
+* __Cache timer:__ 60 minutes <sup style="color: red; font-weight: bold">(see notes below)</sup>
 * __Parameters:__
     <table border="1">
         <tbody>

--- a/docs/xmlapi/character/char_planetarypins.md
+++ b/docs/xmlapi/character/char_planetarypins.md
@@ -3,7 +3,7 @@ Retrieve planetary pins for colonies owned by character.
 
 * __Path:__ ``/char/PlanetaryPins.xml.aspx``
 * __Access mask:__ 2
-* __Cache timer:__ 60 minutes <sup title="Planetary colony information has special update rules.  See notes below" style="color: red">&#x2605;</sup>
+* __Cache timer:__ 60 minutes <sup style="color: red; font-weight: bold">(see notes below)</sup>
 * __Parameters:__
     <table border="1">
         <tbody>

--- a/docs/xmlapi/character/char_planetaryroutes.md
+++ b/docs/xmlapi/character/char_planetaryroutes.md
@@ -3,7 +3,7 @@ Retrieve planetary routes for colonies owned by character.
 
 * __Path:__ ``/char/PlanetaryRoutes.xml.aspx``
 * __Access mask:__ 2
-* __Cache timer:__ 60 minutes <sup title="Planetary colony information has special update rules.  See notes below" style="color: red">&#x2605;</sup>
+* __Cache timer:__ 60 minutes <sup style="color: red; font-weight: bold">(see notes below)</sup>
 * __Parameters:__
     <table border="1">
         <tbody>


### PR DESCRIPTION
…tnotes reference.

This also fixes the issue with building latex files that contain that character.