### PR TITLE
Updated public-crest addresses to new crest-tq.

### DIFF
--- a/docs/crest/character/char_waypoints.md
+++ b/docs/crest/character/char_waypoints.md
@@ -14,7 +14,7 @@ Body format:
   "clearOtherWaypoints": false,
   "first": false,
   "solarSystem": {
-    "href": "https://public-crest.eveonline.com/solarsystems/30000003/",
+    "href": "https://crest-tq.eveonline.com/solarsystems/30000003/",
     "id": 30000003
   }
 }

--- a/docs/crest/eve/eve_alliances.md
+++ b/docs/crest/eve/eve_alliances.md
@@ -16,7 +16,7 @@ The alliances resource allows an application to read alliances data.
         {
             "id_str" : 99000006,
             "shortName" : 666,
-            "href" : "https://public-crest.eveonline.com/alliances/99000006/",
+            "href" : "https://crest-tq.eveonline.com/alliances/99000006/",
             "id" : 99000006,
             "name" : "Everto Rex Regis"
         },
@@ -26,7 +26,7 @@ The alliances resource allows an application to read alliances data.
         { "..." }
     ],
     "next" : {
-        "href" : "https://public-crest.eveonline.com/alliances/?page=2"
+        "href" : "https://crest-tq.eveonline.com/alliances/?page=2"
     },
     "totalCount" : 2989,
     "pageCount_str" : 12
@@ -52,7 +52,7 @@ The alliances resource allows an application to read alliances data.
     "creatorCorporation" : {
         "name" : "Covenant of the Phoenix",
         "isNPC" : false,
-        "href" : "https://public-crest.eveonline.com/corporations/98001096/",
+        "href" : "https://crest-tq.eveonline.com/corporations/98001096/",
         "id_str" : 98001096,
         "logo" : {
             "32x32" : {
@@ -75,9 +75,9 @@ The alliances resource allows an application to read alliances data.
     "creatorCharacter" : {
         "name" : "Jan Shan",
         "isNPC" : false,
-        "href" : "https://public-crest.eveonline.com/characters/681594178/",
+        "href" : "https://crest-tq.eveonline.com/characters/681594178/",
         "capsuleer" : {
-            "href" : "https://public-crest.eveonline.com/characters/681594178/capsuleer/"
+            "href" : "https://crest-tq.eveonline.com/characters/681594178/capsuleer/"
         },
         "portrait" : {
             "32x32" : {

--- a/docs/crest/eve/eve_dogmaAttributes.md
+++ b/docs/crest/eve/eve_dogmaAttributes.md
@@ -15,7 +15,7 @@ The dogma attributes resource allows an application to read dogma attributes.
   "items": [
     {
       "id_str": "2",
-      "href": "https://public-crest.eveonline.com/dogma/attributes/2/",
+      "href": "https://crest-tq.eveonline.com/dogma/attributes/2/",
       "id": 2,
       "name": "isOnline"
     },
@@ -25,7 +25,7 @@ The dogma attributes resource allows an application to read dogma attributes.
     { "..." },
    ],
   "next": {
-    "href": "https://public-crest.eveonline.com/dogma/attributes/?page=2"
+    "href": "https://crest-tq.eveonline.com/dogma/attributes/?page=2"
   },
   "totalCount": 1939,
   "pageCount_str": "4"

--- a/docs/crest/eve/eve_dogmaEffects.md
+++ b/docs/crest/eve/eve_dogmaEffects.md
@@ -15,7 +15,7 @@ The dogma effects resource allows an application to read dogma effects.
   "items": [
     {
       "id_str": "4",
-      "href": "https://public-crest.eveonline.com/dogma/effects/4/",
+      "href": "https://crest-tq.eveonline.com/dogma/effects/4/",
       "id": 4,
       "name": "shieldBoosting"
     },
@@ -25,7 +25,7 @@ The dogma effects resource allows an application to read dogma effects.
     { "..." },
    ],
   "next": {
-    "href": "https://public-crest.eveonline.com/dogma/effects/?page=2"
+    "href": "https://crest-tq.eveonline.com/dogma/effects/?page=2"
   },
   "totalCount": 3896,
   "pageCount_str": "8"

--- a/docs/crest/eve/eve_types.md
+++ b/docs/crest/eve/eve_types.md
@@ -15,7 +15,7 @@ The types resource allows an application to read types.
   "items": [
     {
       "id_str": "0",
-      "href": "https://public-crest.eveonline.com/types/0/",
+      "href": "https://crest-tq.eveonline.com/types/0/",
       "id": 0,
       "name": "#System"
     },
@@ -25,7 +25,7 @@ The types resource allows an application to read types.
     { "..." },
    ],
   "next": {
-    "href": "https://public-crest.eveonline.com/types/?page=2"
+    "href": "https://crest-tq.eveonline.com/types/?page=2"
   },
   "totalCount": 28370,
   "pageCount_str": "29"
@@ -53,7 +53,7 @@ The types resource allows an application to read types.
       {
         "attribute": {
           "id_str": "4",
-          "href": "https://public-crest.eveonline.com/dogma/attributes/4/",
+          "href": "https://crest-tq.eveonline.com/dogma/attributes/4/",
           "id": 4,
           "name": "mass"
         },

--- a/docs/crest/eve/eve_wars.md
+++ b/docs/crest/eve/eve_wars.md
@@ -14,7 +14,7 @@ The wars resource allows an application to read wars data.
   "pageCount": 239,
   "items": [
     {
-      "href": "https://public-crest.eveonline.com/wars/1/",
+      "href": "https://crest-tq.eveonline.com/wars/1/",
       "id": 1,
       "id_str": "1"
     },
@@ -24,7 +24,7 @@ The wars resource allows an application to read wars data.
     { "..." },
    ],
   "next": {
-    "href": "https://public-crest.eveonline.com/wars/?page=2"
+    "href": "https://crest-tq.eveonline.com/wars/?page=2"
   },
   "totalCount": 477886,
   "pageCount_str": "239"
@@ -49,7 +49,7 @@ The wars resource allows an application to read wars data.
     "shipsKilled": 0,
     "shipsKilled_str": "0",
     "name": "Privateer Alliance",
-    "href": "https://public-crest.eveonline.com/alliances/753644383/",
+    "href": "https://crest-tq.eveonline.com/alliances/753644383/",
     "id_str": "753644383",
     "icon": {
       "href": "http://imageserver.eveonline.com/Alliance/753644383_128.png"
@@ -59,13 +59,13 @@ The wars resource allows an application to read wars data.
   },
   "mutual": false,
   "allyCount_str": "0",
-  "killmails": "https://public-crest.eveonline.com/wars/42000/killmails/all/",
+  "killmails": "https://crest-tq.eveonline.com/wars/42000/killmails/all/",
   "id_str": "42000",
   "defender": {
     "shipsKilled": 0,
     "shipsKilled_str": "0",
     "name": "Ka-Tet",
-    "href": "https://public-crest.eveonline.com/alliances/389924442/",
+    "href": "https://crest-tq.eveonline.com/alliances/389924442/",
     "id_str": "389924442",
     "icon": {
       "href": "http://imageserver.eveonline.com/Alliance/389924442_128.png"

--- a/docs/crest/map/map_constellations.md
+++ b/docs/crest/map/map_constellations.md
@@ -14,7 +14,7 @@ The constellations resource allows an application to read constellations.
   "items": [
     {
       "id_str": "20000001",
-      "href": "https://public-crest.eveonline.com/constellations/20000001/",
+      "href": "https://crest-tq.eveonline.com/constellations/20000001/",
       "id": 20000001,
       "name": "San Matar"
     },
@@ -44,11 +44,11 @@ The constellations resource allows an application to read constellations.
     "z": -9760976595570807000
   },
   "region": {
-    "href": "https://public-crest.eveonline.com/regions/11000016/"
+    "href": "https://crest-tq.eveonline.com/regions/11000016/"
   },
   "systems": [
     {
-      "href": "https://public-crest.eveonline.com/solarsystems/31002538/",
+      "href": "https://crest-tq.eveonline.com/solarsystems/31002538/",
       "id": 31002538,
       "id_str": "31002538"
     },

--- a/docs/crest/map/map_planets.md
+++ b/docs/crest/map/map_planets.md
@@ -27,10 +27,10 @@ The planets resource allows an application to read planets data.
     "z": 49900095982
   },
   "type": {
-    "href": "https://public-crest.eveonline.com/types/2016/"
+    "href": "https://crest-tq.eveonline.com/types/2016/"
   },
   "system": {
-    "href": "https://public-crest.eveonline.com/solarsystems/30000032/",
+    "href": "https://crest-tq.eveonline.com/solarsystems/30000032/",
     "name": "Hasiari"
   },
   "name": "Hasiari I"

--- a/docs/crest/map/map_regions.md
+++ b/docs/crest/map/map_regions.md
@@ -14,7 +14,7 @@ The regions resource allows an application to read regions.
   "items": [
     {
       "id_str": "11000001",
-      "href": "https://public-crest.eveonline.com/regions/11000001/",
+      "href": "https://crest-tq.eveonline.com/regions/11000001/",
       "id": 11000001,
       "name": "A-R00001"
     },
@@ -40,11 +40,11 @@ The regions resource allows an application to read regions.
 {
   "description": "It has long been an established fact of civilization [...]",
   "marketBuyOrders": {
-    "href": "https://public-crest.eveonline.com/market/10000042/orders/buy/"
+    "href": "https://crest-tq.eveonline.com/market/10000042/orders/buy/"
   },
   "constellations": [
     {
-      "href": "https://public-crest.eveonline.com/constellations/20000302/",
+      "href": "https://crest-tq.eveonline.com/constellations/20000302/",
       "id": 20000302,
       "id_str": "20000302"
     },
@@ -57,7 +57,7 @@ The regions resource allows an application to read regions.
   "id_str": "10000042",
   "id": 10000042,
   "marketSellOrders": {
-    "href": "https://public-crest.eveonline.com/market/10000042/orders/sell/"
+    "href": "https://crest-tq.eveonline.com/market/10000042/orders/sell/"
   }
 }
 ```

--- a/docs/crest/map/map_solarsystems.md
+++ b/docs/crest/map/map_solarsystems.md
@@ -14,7 +14,7 @@ The solar systems resource allows an application to read solar systems.
   "items": [
     {
       "id_str": "30000001",
-      "href": "https://public-crest.eveonline.com/solarsystems/30000001/",
+      "href": "https://crest-tq.eveonline.com/solarsystems/30000001/",
       "id": 30000001,
       "name": "Tanoo"
     },
@@ -39,16 +39,16 @@ The solar systems resource allows an application to read solar systems.
 ```json
 {
   "stats": {
-    "href": "https://public-crest.eveonline.com/solarsystems/30000032/stats/"
+    "href": "https://crest-tq.eveonline.com/solarsystems/30000032/stats/"
   },
   "name": "Hasiari",
   "securityStatus": 0.7981876134872437,
   "securityClass": "B",
-  "href": "https://public-crest.eveonline.com/solarsystems/30000032/",
+  "href": "https://crest-tq.eveonline.com/solarsystems/30000032/",
   "id_str": "30000032",
   "planets": [
     {
-      "href": "https://public-crest.eveonline.com/planets/40002133/"
+      "href": "https://crest-tq.eveonline.com/planets/40002133/"
     },
     { "..." },
     { "..." },
@@ -62,12 +62,12 @@ The solar systems resource allows an application to read solar systems.
   },
   "sovereignty": {
     "id_str": "500007",
-    "href": "https://public-crest.eveonline.com/alliances/500007/",
+    "href": "https://crest-tq.eveonline.com/alliances/500007/",
     "id": 500007,
     "name": "Ammatar Mandate"
   },
   "constellation": {
-    "href": "https://public-crest.eveonline.com/constellations/20000005/",
+    "href": "https://crest-tq.eveonline.com/constellations/20000005/",
     "id": 20000005,
     "id_str": "20000005"
   },


### PR DESCRIPTION
Addresses now use https://crest-tq.eveonline.com.