### PR TITLE
Include examples of JSON use in SSO request bodies

### DIFF
--- a/docs/sso/authentication.md
+++ b/docs/sso/authentication.md
@@ -27,7 +27,7 @@ At this point your website has the authorization code. The only thing the author
 
 It is also important to note that the authorization code is single use only.
 
-The you need to make an HTTP POST to `https://login.eveonline.com/oauth/token` to exchange the authorization code with an access token. Example request:
+You need to make a POST request to `https://login.eveonline.com/oauth/token` to exchange the authorization code for an access token. Example request:
 ```http
 POST https://login.eveonline.com/oauth/token HTTP/1.1
 

--- a/docs/sso/authentication.md
+++ b/docs/sso/authentication.md
@@ -2,55 +2,55 @@
 ## Implementing the SSO
 The recommended flow for web applications where the client secret can be stored on a server is the Authorization Code Grant documented [here](http://tools.ietf.org/html/rfc6749#section-4.1).
 
-For those users that don't feel like reading the standard the authentication is really just a series of HTTPS requests and redirects described in this document.
+For those that don't feel like reading the standard, the authentication is really just a series of HTTP requests and redirects described in this document.
 
 ## Redirect to the SSO
-When a user clicks the "login" button on a your website you need to redirect the user with HTTP 302 redirect to `https://login.eveonline.com/oauth/authorize` with the following query string parameters:
+When a user clicks the login button on your website you need to redirect the user to `https://login.eveonline.com/oauth/authorize` with the following query string parameters:
+- response_type: Must be set to "code".
+- redirect_uri: After authentication the user will be redirected to this URL on your website. It must match the definition on file in the developers site.
+- client_id: A string identifier for the client, provided by CCP.
+- scope: The requested scopes as a space delimited string.
+- state: An opaque value used by the client to maintain state between the request and callback. The SSO includes this value when redirecting back to the 3rd party website. While not required, it is important to use this for security reasons. [http://www.thread-safe.com/2014/05/the-correct-use-of-state-parameter-in.html](http://www.thread-safe.com/2014/05/the-correct-use-of-state-parameter-in.html) explains why the state parameter is needed.
 
-- response_type - Must be set to "code".
-- redirect_uri - After authentication the user will be redirected to this URL on your website, it must match the definition on file in the SSO.P
-- client_id - A string identifier for the client, provided by CCP.
-- scope - The requested scopes as a space delimited string.
-- state (OPTIONAL but recommended) - An opaque value used by the client to maintain state between the request and callback. The SSO includes this value when redirecting back to the 3rd party website. While not required, it is important to use this for security reasons. [http://www.thread-safe.com/2014/05/the-correct-use-of-state-parameter-in.html](http://www.thread-safe.com/2014/05/the-correct-use-of-state-parameter-in.html) explains why the state parameter is needed.
+Example URL: `https://login.eveonline.com/oauth/authorize/?response_type=code&redirect_uri=https://3rdpartysite.com/callback&client_id=3rdpartyClientId&scope=&state=uniquestate123`
 
-**Example URL:** [https://login.eveonline.com/oauth/authorize/?response_type=code&redirect_uri=https://3rdpartysite.com/callback&client_id=3rdpartyClientId&scope=&state=uniquestate123](https://login.eveonline.com/oauth/authorize/?response_type=code&redirect_uri=https://3rdpartysite.com/callback&client_id=3rdpartyClientId&scope=&state=uniquestate123)
+The user will need to log into their EVE Online account and select the character that your web site will be given access to. If the user is already logged in with an EVE Online account, they will just need to select a character and approve the required scopes.
 
-The user will need to authenticate with a username/password on the SSO and select the character that your web site will be given access to. If the user has previously logged in to some other website the authentication has already been done, this is single sign-on after all, and they will just need to select a character and approve the required scopes.
+The SSO will redirect the user back to the provided callback URL with an authorization code and the state as query string parameters.
 
-The SSO will redirect the user back to the provided `callback_uri` with an authorization code and the state as query string parameters.
-
-That will look something like this: [https://3rdpartysite.com/callback?code=gEyuYF_rf...ofM0&state=uniquestate123](https://3rdpartysite.com/callback?code=gEyuYF_rf...ofM0&state=uniquestate123)
-
-- code - The Authorization code.
-- state - The state parameter that was sent in the original request to the SSO.
+Example URL: `https://3rdpartysite.com/callback?code=gEyuYF_rf...ofM0&state=uniquestate123`
+- code: The Authorization code.
+- state: The state parameter that was sent in the original request to the SSO.
 
 ## Verify the authorization code
-At this point in time your website has the authorization code. The only thing the authorization code is good for is to obtain an access token.
+At this point your website has the authorization code. The only thing the authorization code is good for is to obtain an access token.
 
 It is also important to note that the authorization code is single use only.
 
-The you need to make an HTTP POST to `https://login.eveonline.com/oauth/token` to exchange the authorization code with an access token, and it looks like this:
+The you need to make an HTTP POST to `https://login.eveonline.com/oauth/token` to exchange the authorization code with an access token. Example request:
 ```http
 POST https://login.eveonline.com/oauth/token HTTP/1.1
 
 Authorization: Basic bG9...ZXQ=
-Content-Type: application/x-www-form-urlencoded
+Content-Type: application/json
 Host: login.eveonline.com
 
-grant_type=authorization_code&code=gEyuYF_rf...ofM0
+{
+  "grant_type":"authorization_code",
+  "code":"gEyuYF_rf...ofM0"
+}
 ```
-- Authorization HTTP header: This is the string "Basic" plus the string {client_id}:{client_secret} Base64 encoded
-    - NOTE: It is very important to make sure there are no spaces or newline characters in the string that is being Base64 encoded. If in doubt, try to Base64 encode these sample values and compare to the one below.
-    - Example values:
-        - client_id = 3rdparty_clientid
-        - client_secret=jkfopwkmif90e0womkepowe9irkjo3p9mkfwe
-        - Concatenated to become: 3rdparty_clientid:jkfopwkmif90e0womkepowe9irkjo3p9mkfwe
-    - Resulting in Base64-encoded Authorization header
-        - Authorization: Basic M3JkcGFydHlfY2xpZW50aWQ6amtmb3B3a21pZjkwZTB3b21rZXBvd2U5aXJram8zcDlta2Z3ZQ==
-- grant_type=authorization_code: This is fixed and doesn't change
-- code: The authorization code obtained in Step 1. Make sure there are no extra spaces or newline characters at the end of the HTTP body.
+- Authorization HTTP header: [Basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) is used, with the client ID as the username and secret key as the password. The header should be the string "Basic " plus the [Base64](https://en.wikipedia.org/wiki/Base64) encoded string `{client_id}:{client_secret}`.
+    - It is very important to make sure there is no whitespace around or in the string that is being Base64 encoded. If in doubt, try to Base64 encode the sample values provided below and compare them to the results:
+        - Example client ID: `3rdparty_clientid`
+        - Example secret key: `jkfopwkmif90e0womkepowe9irkjo3p9mkfwe`
+        - Concatenated to become: `3rdparty_clientid:jkfopwkmif90e0womkepowe9irkjo3p9mkfwe`
+        - Base64 encoded to: `M3JkcGFydHlfY2xpZW50aWQ6amtmb3B3a21pZjkwZTB3b21rZXBvd2U5aXJram8zcDlta2Z3ZQ==`
+        - Resulting in the Authorization header: `Basic M3JkcGFydHlfY2xpZW50aWQ6amtmb3B3a21pZjkwZTB3b21rZXBvd2U5aXJram8zcDlta2Z3ZQ==`
+- grant_type: Must be set to "authorization_code".
+- code: The authorization code obtained earlier.
 
-A successful verification request will yield a response in [JSON](http://www.json.org/) format similar to the following:
+A successful verification request will yield a response containing details about the access token. Example:
 ```json
 {
     "access_token": "uNEEh...a\_WpiaA2",
@@ -59,4 +59,3 @@ A successful verification request will yield a response in [JSON](http://www.jso
     "refresh_token": null
 }
 ```
-The access token returned is valid for 1200 seconds, or 20 minutes.

--- a/docs/sso/authentication.md
+++ b/docs/sso/authentication.md
@@ -12,7 +12,7 @@ When a user clicks the login button on your website you need to redirect the use
 - scope: The requested scopes as a space delimited string.
 - state: An opaque value used by the client to maintain state between the request and callback. The SSO includes this value when redirecting back to the 3rd party website. While not required, it is important to use this for security reasons. [http://www.thread-safe.com/2014/05/the-correct-use-of-state-parameter-in.html](http://www.thread-safe.com/2014/05/the-correct-use-of-state-parameter-in.html) explains why the state parameter is needed.
 
-Example URL: `https://login.eveonline.com/oauth/authorize/?response_type=code&redirect_uri=https://3rdpartysite.com/callback&client_id=3rdpartyClientId&scope=&state=uniquestate123`
+Example URL: `https://login.eveonline.com/oauth/authorize/?response_type=code&redirect_uri=https%3A%2F%2F3rdpartysite.com%2Fcallback&client_id=3rdpartyClientId&scope=characterContactsRead%20characterContactsWrite&state=uniquestate123`
 
 The user will need to log into their EVE Online account and select the character that your web site will be given access to. If the user is already logged in with an EVE Online account, they will just need to select a character and approve the required scopes.
 
@@ -32,13 +32,10 @@ You need to make a POST request to `https://login.eveonline.com/oauth/token` to 
 POST https://login.eveonline.com/oauth/token HTTP/1.1
 
 Authorization: Basic bG9...ZXQ=
-Content-Type: application/json
+Content-Type: application/x-www-form-urlencoded
 Host: login.eveonline.com
 
-{
-  "grant_type":"authorization_code",
-  "code":"gEyuYF_rf...ofM0"
-}
+grant_type=authorization_code&code=gEyuYF_rf...ofM0
 ```
 - Authorization HTTP header: [Basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) is used, with the client ID as the username and secret key as the password. The header should be the string "Basic " plus the [Base64](https://en.wikipedia.org/wiki/Base64) encoded string `{client_id}:{client_secret}`.
     - It is very important to make sure there is no whitespace around or in the string that is being Base64 encoded. If in doubt, try to Base64 encode the sample values provided below and compare them to the results:
@@ -50,12 +47,26 @@ Host: login.eveonline.com
 - grant_type: Must be set to "authorization_code".
 - code: The authorization code obtained earlier.
 
+Alternatively, while not in accordance with the OAuth 2.0 standard, the body of the request may use JSON encoding. Example:
+```http
+POST https://login.eveonline.com/oauth/token HTTP/1.1
+
+Authorization: Basic bG9...ZXQ=
+Content-Type: application/json
+Host: login.eveonline.com
+
+{
+  "grant_type":"authorization_code",
+  "code":"gEyuYF_rf...ofM0"
+}
+```
+
 A successful verification request will yield a response containing details about the access token. Example:
 ```json
 {
-    "access_token": "uNEEh...a\_WpiaA2",
-    "token_type": "Bearer",
-    "expires_in": 300,
-    "refresh_token": null
+    "access_token":"uNEEh...a_WpiaA2",
+    "token_type":"Bearer",
+    "expires_in":1200,
+    "refresh_token":"gEy...fM0"
 }
 ```

--- a/docs/sso/intro.md
+++ b/docs/sso/intro.md
@@ -5,11 +5,13 @@ Simply put, SSOs are a way for users to log into one web site using their userna
 For EVE Online, the SSO means that you can sign into a web site that has integrated the EVE SSO and confirm you are a specific character. While signing into a site you will be asked which character you wish to authenticate with and the web site that let you sign in with the EVE SSO will get confirmation from CCP that you own that character. The original web site will only ever get your character, they never see your account name or password. The original web site will not know what account that character is on or have any way, from us at least, of linking that character to any other character on the same account.
 
 ## Registering for the SSO
-To use the SSO in your app, you must first register it at [the developers' site](https://developers.eveonline.com/). When you create a new application here it will give you a client ID and secret key, which are used in the authentication flow.
+To use the SSO in your app, you must first register it at [the developers site](https://developers.eveonline.com/). When you create a new application here it will give you a client ID and secret key, which are used in the authentication flow.
 
-You are required to supply a callback URL and this is the only location the login server will redirect back to after the user has authorised the login (see the authentication flow for details).
-
-You will also be asked to select what authentication scopes your application will ask for. At present, the only one is publicData, which gives access to market orders.
+You are required to supply the following:
+- Name: Name of the application, will be displayed to the users when asked to authorize your app.
+- Description: Description of the application, will be listed under your app in [Third Party Applications](https://community.eveonline.com/support/third-party-applications/).
+- Connection type: Can be CREST Access or Authentication Only. If CREST Access is selected, you will also need to select the scopes your app will use.
+- Callback URL: Callback URL, which is the only location the login server will redirect back to after the user has authorized the login (See [Authentication flow](authentication.md) for details.)
 
 ### Errors
 Please note:

--- a/docs/sso/refreshtokens.md
+++ b/docs/sso/refreshtokens.md
@@ -1,22 +1,45 @@
 # Refresh Tokens
-If any valid scope was requested in the initial redirect to the SSO, a refresh token will be returned by the token endpoint, along with the access token. While the access token will expire after a set interval - currently 20 minutes, the refresh token can be stored and used indefinitely. (Users can revoke access for individual apps on the support site)
+If any valid scope was requested in the initial redirect to the SSO, a refresh token will be returned by the token endpoint, along with the access token. While the access token will expire after a set interval, the refresh token can be stored and used indefinitely. Users can revoke access for individual apps on the [support site](https://community.eveonline.com/support/third-party-applications/).
 
-To get a new access token you make a POST request to "https://login.eveonline.com/oauth/token" with the following params:
+To get a new access token you must make a POST request to "https://login.eveonline.com/oauth/token" with the following parameters:
+- grant_type - Must be set to "refresh_token".
+- refresh_token - The refresh token recieved from the last request to the token endpoint.
+
+Example request body:
+```json
+{
+  "grant_type":"refresh_token",
+  "refresh_token":"gEy...fM0"
+}
+```
+
+You also need to include the same Authentication header ([basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) with the client ID as the username and secret key as password) which was used for previous requests to the token endpoint.
+Example:
 ```http
-grant_type=refresh_token&refresh_token=USERS_REFRESH_TOKEN
-```    
-You also need to include the same Authentication header (base64 encoded) as you used for the first call to the token endpoint. Example:
-```http
-Authorization: Basic [Base64 encoded client_id:client_secret]
-```    
-So your call will look like
+Authorization: Basic bG9...ZXQ=
+```
+
+After all that, your request should look like this:
 ```http
 POST https://login.eveonline.com/oauth/token HTTP/1.1
 
 Authorization: Basic bG9...ZXQ=
-Content-Type: application/x-www-form-urlencoded
+Content-Type: application/json
 Host: login.eveonline.com
 
-grant_type=refresh_token&refresh_token=gEyuYF_rf...ofM0
+{
+  "grant_type":"refresh_token",
+  "refresh_token":"gEy...fM0"
+}
 ```
-The json formatted response should contain a new access token for that user, along with the time until it expires.
+
+The response should contain details about the new access token for that user. Example:
+```json
+{
+  "access_token": "MXP...tg2",
+  "token_type": "Bearer",
+  "expires_in": 1200,
+  "refresh_token": "gEy...fM0"
+}
+```
+

--- a/docs/sso/refreshtokens.md
+++ b/docs/sso/refreshtokens.md
@@ -1,5 +1,5 @@
 # Refresh Tokens
-If any valid scope was requested in the initial redirect to the SSO, a refresh token will be returned by the token endpoint, along with the access token. While the access token will expire after a set interval, the refresh token can be stored and used indefinitely. Users can revoke access for individual apps on the [support site](https://community.eveonline.com/support/third-party-applications/).
+If any valid scope was requested in the initial redirect to the SSO, a refresh token will be returned by the token endpoint, along with the access token. While the access token will expire after the listed interval, the refresh token can be stored and used indefinitely. Users can revoke access for individual apps on the [support site](https://community.eveonline.com/support/third-party-applications/).
 
 To get a new access token you must make a POST request to `https://login.eveonline.com/oauth/token` with the following parameters:
 - grant_type: Must be set to "refresh_token".
@@ -8,6 +8,17 @@ To get a new access token you must make a POST request to `https://login.eveonli
 You also need to include the same Authentication header ([basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) with the client ID as the username and secret key as the password) which was used for previous requests to the token endpoint.
 
 The request should look like this:
+```http
+POST https://login.eveonline.com/oauth/token HTTP/1.1
+
+Authorization: Basic bG9...ZXQ=
+Content-Type: application/x-www-form-urlencoded
+Host: login.eveonline.com
+
+grant_type=refresh_token&refresh_token=gEy...fM0
+```
+
+Alternatively, the body of the request may use JSON:
 ```http
 POST https://login.eveonline.com/oauth/token HTTP/1.1
 
@@ -24,10 +35,9 @@ Host: login.eveonline.com
 The response should contain details about the new access token for that user. Example:
 ```json
 {
-  "access_token": "MXP...tg2",
-  "token_type": "Bearer",
-  "expires_in": 1200,
-  "refresh_token": "gEy...fM0"
+  "access_token":"MXP...tg2",
+  "token_type":"Bearer",
+  "expires_in":1200,
+  "refresh_token":"gEy...fM0"
 }
 ```
-

--- a/docs/sso/refreshtokens.md
+++ b/docs/sso/refreshtokens.md
@@ -1,25 +1,13 @@
 # Refresh Tokens
 If any valid scope was requested in the initial redirect to the SSO, a refresh token will be returned by the token endpoint, along with the access token. While the access token will expire after a set interval, the refresh token can be stored and used indefinitely. Users can revoke access for individual apps on the [support site](https://community.eveonline.com/support/third-party-applications/).
 
-To get a new access token you must make a POST request to "https://login.eveonline.com/oauth/token" with the following parameters:
-- grant_type - Must be set to "refresh_token".
-- refresh_token - The refresh token recieved from the last request to the token endpoint.
+To get a new access token you must make a POST request to `https://login.eveonline.com/oauth/token` with the following parameters:
+- grant_type: Must be set to "refresh_token".
+- refresh_token: The refresh token recieved from the last request to the token endpoint.
 
-Example request body:
-```json
-{
-  "grant_type":"refresh_token",
-  "refresh_token":"gEy...fM0"
-}
-```
+You also need to include the same Authentication header ([basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) with the client ID as the username and secret key as the password) which was used for previous requests to the token endpoint.
 
-You also need to include the same Authentication header ([basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) with the client ID as the username and secret key as password) which was used for previous requests to the token endpoint.
-Example:
-```http
-Authorization: Basic bG9...ZXQ=
-```
-
-After all that, your request should look like this:
+The request should look like this:
 ```http
 POST https://login.eveonline.com/oauth/token HTTP/1.1
 


### PR DESCRIPTION
While the OAuth 2.0 standard suggests the use of `application/x-www-form-urlencoded` encoded request bodies, EVE Online SSO supports the use of JSON encoded request bodies, which are already used both for requests and responses in CREST, and for responses in the SSO itself.
Thus, it might be beneficial for the documentation to describe the use of JSON for SSO request bodies, to avoid format inconsistencies between requests and responses in CREST and SSO.

Aside from the change to JSON, I've also made multiple smaller edits to fix some typos, modify wording and change formatting to make the two pages clearer. If the main changes are not considered to be beneficial, feel free to close the PR.