### PR TITLE
Using XML API with SSO access tokens

### DIFF
--- a/docs/xmlapi/account/account_accountstatus.md
+++ b/docs/xmlapi/account/account_accountstatus.md
@@ -2,28 +2,9 @@
 Information about a player's EVE account like creation time, minutes spent in game etc.  
 
 * __Path:__ ``/account/AccountStatus.xml.aspx``
-* __Access mask:__ 33554432
 * __Cache timer:__ 1 hour
-* __Parameters:__
-    <table border="1">
-        <tbody>
-            <tr>
-                <th>Argument</th>
-                <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char(64)</strong></td>
-                <td>API verification code</td>
-            </tr>
-        </tbody>
-    </table>
+* __Access mask:__ 33554432
+* __Parameters:__ none
 
 ### Sample Response
 

--- a/docs/xmlapi/account/account_apikeyinfo.md
+++ b/docs/xmlapi/account/account_apikeyinfo.md
@@ -2,28 +2,9 @@
 Specifies the access rights of an API key.  
 
 * __Path:__ ``/account/APIKeyInfo.xml.aspx``
-* __Access mask:__ none
 * __Cache timer:__ 5 minutes
-* __Parameters:__
-    <table border="1">
-        <tbody>
-            <tr>
-                <th>Argument</th>
-                <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>The ID of the Customizable API Key (CAK) for authentication.</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char(64)</strong></td>
-                <td>The user defined or CCP generated <em>Verification Code</em> for the CAK.</td>
-            </tr>
-        </tbody>
-    </table>
+* __Access mask:__ 0
+* __Parameters:__ none
 
 ### Sample Response
 

--- a/docs/xmlapi/account/account_characters.md
+++ b/docs/xmlapi/account/account_characters.md
@@ -2,28 +2,9 @@
 Lists all characters included in this API key.  
 
 * __Path:__ ``/account/Characters.xml.aspx``
-* __Access mask:__ -  
-* __Cache timer:__ 1 hour  
-* __Parameters:__
-    <table border="1">
-        <tbody>
-            <tr>
-                <th>Argument</th>
-                <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
-            </tr>
-        </tbody>
-    </table>
+* __Cache timer:__ 1 hour
+* __Access mask:__ 0
+* __Parameters:__ none
 
 ### Sample Response
 

--- a/docs/xmlapi/api/api_calllist.md
+++ b/docs/xmlapi/api/api_calllist.md
@@ -2,9 +2,9 @@
 List of all selectable API endpoints/groups to which an API grants access to.
 
 * __Path:__ ``/api/CallList.xml.aspx``  
-* __Access mask:__ -  
 * __Cache timer:__ 6 hours  
-* __Parameters:__ -  
+* __Access mask:__ none  
+* __Parameters:__ none  
 
 ### Sample Response
 

--- a/docs/xmlapi/authentication.md
+++ b/docs/xmlapi/authentication.md
@@ -1,5 +1,50 @@
 # Authentication
+There are two methods of authentication available for use with the XML API.
 
-``` eval_rst 
-.. include:: /stub-notice.rst
-```
+## API keys
+API keys may be created, updated and deleted by users at the [API Key Management](https://community.eveonline.com/support/api-key/) page.
+
+## SSO access tokens
+
+
+### Scope to access mask mappings
+These tables list the SSO scopes which allow access to the XML API and the access masks they map to.
+
+#### Character access
+SSO scope | Access mask
+:--- | ---:
+characterWalletRead | 1 &#124; 2097152 &#124; 4194304
+characterAssetsRead | 2 &#124; 134217728
+characterCalendarRead | 4 &#124; 1048576
+characterContactsRead | 16 &#124; 32 &#124; 524288
+characterFactionalWarfareRead | 64
+characterIndustryJobsRead | 128
+characterKillsRead | 256
+characterMailRead | 512 &#124; 1024 &#124; 2048
+characterMarketOrdersRead | 4096
+characterMedalsRead | 8192
+characterNotificationsRead | 16384 &#124; 32768
+characterResearchRead | 65536
+characterSkillsRead | 131072 &#124; 262144 &#124; 1073741824
+characterAccountRead | 33554432
+characterContractsRead | 67108864
+characterBookmarksRead | 268435456
+characterChatChannelsRead | 536870912
+characterClonesRead | 2147483648
+
+#### Corporation access
+SSO scope | Access mask
+:--- | ---:
+corporationWalletRead | 1 &#124; 8 &#124; 1048576 &#124; 2097152
+corporationAssetsRead | 2 &#124; 32 &#124; 16777216
+corporationMedalsRead | 4 &#124; 8192
+corporationContactsRead | 16 &#124; 262144
+corporationFactionalWarfareRead | 64
+corporationIndustryJobsRead | 128
+corporationKillsRead | 256
+corporationMembersRead | 512 &#124; 1024 &#124; 2048 &#124; 4194304 &#124; 33554432
+corporationMarketOrdersRead | 4096
+corporationStructuresRead | 16384 &#124; 32768 &#124; 131072
+corporationShareholdersRead | 65536
+corporationContractsRead | 8388608
+corporationBookmarksRead | 67108864

--- a/docs/xmlapi/authentication.md
+++ b/docs/xmlapi/authentication.md
@@ -38,14 +38,24 @@ ownerID | 0 or a valid character/corporation ID | 0 | Character or corporation w
 For example, to request an account wide API key which gives you access to mail of all characters on that account, you can provide your users with the following link: `https://community.eveonline.com/support/api-key/CreatePredefined?accessMask=3584`
 
 ## SSO access tokens
+SSO access tokens are another method for accessing private endpoints. Compared to API keys, they are more limited as they can't be used for account access. Aside from that limitation, using this method will make things easier for your users as they won't have to bother with creating an API key and giving you the details: they just have to authorize your SSO app.
 
+### Usage
+To authenticate using an SSO access token, include the access token as a parameter in the URL. As an access token may contain scopes for both character and corporation access, you must also define which one you will be using.
+
+| Parameter | Value |
+| --------- | ----- |
+accessToken | SSO access token.
+accessType | Should be set to `character` or `corporation`, depending on which type of access is required. Optional, defaults to `character`.
+
+Example: `https://api.eveonline.com/account/AccountStatus.xml.aspx?keyID=5342860&vCode=1JlLzA5N7fsKh0keyYfFQtkCfm4VvnO4coFXXUDun2ySQjd66AxxJF0OxljvdwdZ`
 
 ### Scope to access mask mappings
-These tables list the SSO scopes which allow access to the XML API and the access masks they map to.
+These tables list the SSO scopes which allow access to the XML API and the access masks they map to. To check which access mask an access token provides, you may also make a call to the [/account/APIKeyInfo.xml.aspx](account/account_apikeyinfo.md) endpoint using the token.
 
 #### Character access
-SSO scope | Access mask
-:--- | ---:
+| SSO scope | Access mask |
+| :-------- | ----------: |
 characterWalletRead | 1 &#124; 2097152 &#124; 4194304
 characterAssetsRead | 2 &#124; 134217728
 characterCalendarRead | 4 &#124; 1048576
@@ -66,8 +76,8 @@ characterChatChannelsRead | 536870912
 characterClonesRead | 2147483648
 
 #### Corporation access
-SSO scope | Access mask
-:--- | ---:
+| SSO scope | Access mask |
+| :-------- | ----------: |
 corporationWalletRead | 1 &#124; 8 &#124; 1048576 &#124; 2097152
 corporationAssetsRead | 2 &#124; 32 &#124; 16777216
 corporationMedalsRead | 4 &#124; 8192

--- a/docs/xmlapi/authentication.md
+++ b/docs/xmlapi/authentication.md
@@ -48,7 +48,7 @@ To authenticate using an SSO access token, include the access token as a paramet
 accessToken | SSO access token.
 accessType | Should be set to `character` or `corporation`, depending on which type of access is required. Optional, defaults to `character`.
 
-Example: `https://api.eveonline.com/account/AccountStatus.xml.aspx?keyID=5342860&vCode=1JlLzA5N7fsKh0keyYfFQtkCfm4VvnO4coFXXUDun2ySQjd66AxxJF0OxljvdwdZ`
+Example: `https://api.eveonline.com/char/AccountBalance.xml.aspx?characterID=93265215&accessToken=Ls-vx-xMqq03cl7yMPWdWTVyp1TQUod7WyXti_EmuEVaUMt5JQibftknW06mtFDfhLS7khMP7S93QxXeUzGnxw2`
 
 ### Scope to access mask mappings
 These tables list the SSO scopes which allow access to the XML API and the access masks they map to. To check which access mask an access token provides, you may also make a call to the [/account/APIKeyInfo.xml.aspx](account/account_apikeyinfo.md) endpoint using the token.

--- a/docs/xmlapi/authentication.md
+++ b/docs/xmlapi/authentication.md
@@ -1,8 +1,41 @@
 # Authentication
-There are two methods of authentication available for use with the XML API.
+There are two methods of authentication available for use with the XML API. As the XML API is a read-only API and only supports GET requests, both involve adding parameters to the query string.
 
 ## API keys
-API keys may be created, updated and deleted by users at the [API Key Management](https://community.eveonline.com/support/api-key/) page.
+API keys are the primary method of accessing private XML API endpoints. They may be created, updated and deleted by users at the [API Key Management](https://community.eveonline.com/support/api-key/) page.
+
+### Usage
+To authenticate using an API key, include the key ID and verification code as parameters in the URL.
+
+| Parameter | Value |
+| --------- | ----- |
+keyID | Key ID of the API key.
+vCode | Verification code of the API key.
+
+Example: `https://api.eveonline.com/account/AccountStatus.xml.aspx?keyID=5342860&vCode=1JlLzA5N7fsKh0keyYfFQtkCfm4VvnO4coFXXUDun2ySQjd66AxxJF0OxljvdwdZ`
+
+### API key parameters
+- Name: Name of the API key. Does not have to be unique, and is only visible to the owner of the API key. Irrelevant to end users of the API key, but may make API key management easier for their owners.
+- Key ID: Unique ID of the API key. May not be changed.
+- Verification code: Alphanumeric string consisting of up to 64 characters. By default, a random full length code will be generated, but the owner may use a verification code of any length. Matches the regular expression `[a-zA-Z0-9]{1,64}`
+- Access mask: Bitmask defining which endpoints the API key will provide access to.
+- Type: Two main types of API keys are character and corporation keys. Character keys can be further divided into character keys, which provide access to only one chracter, and account keys, which provide access to all characters on an account. Only directors of a corporation may create corporation API keys.
+- Expiry date: How long the API key will be valid. By default, API keys are valid for 1 year from the date of creation, but that date may be changed and they may also be set to never expire. Expired API keys may be reactivated by changing the expiry date.
+
+Provided you have the key ID and verification code of an API key, you can use the [/account/APIKeyInfo.xml.aspx](account/account_apikeyinfo.md) endpoint to retrieve most information about it. As all properties of an API key except the key ID may be modified by the owner at any time, it is good practive to use this endpoint for monitoring stored API keys.
+
+### Create predefined API keys
+It is possible to ease the process of requesting a specific API key from someone by providing them with a CreatePredefined link. It will take them to the API key creation page, but some or all of the fields may be predefined by the link.
+
+The base URL is `https://community.eveonline.com/support/api-key/CreatePredefined`, and presets are defined by adding a query string to that URL. The parameters which may be used are:
+
+| Name | Values | Default | Description |
+| ---- | ------ | ------- | ----------- |
+accessMask | Valid access mask | 0 | The access mask which the API key should have.
+ownerType | `Character` or `Corporation` | `Character` |  Type of the API key which should be created. Whether a character key is account wide or not is determined by another property.
+ownerID | 0 or a valid character/corporation ID | 0 | Character or corporation which the API key applies to. Value of 0 will create an account key instead of a character key.
+
+For example, to request an account wide API key which gives you access to mail of all characters on that account, you can provide your users with the following link: `https://community.eveonline.com/support/api-key/CreatePredefined?accessMask=3584`
 
 ## SSO access tokens
 

--- a/docs/xmlapi/character/char_accountbalance.md
+++ b/docs/xmlapi/character/char_accountbalance.md
@@ -2,25 +2,15 @@
 Retrieve character account balance.
 
 * __Path:__ ``/char/AccountBalance.xml.aspx``
-* __Access mask:__ 1
 * __Cache timer:__ 15 minutes  
+* __Access mask:__ 1  
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_assetlist.md
+++ b/docs/xmlapi/character/char_assetlist.md
@@ -2,25 +2,15 @@
 Lists everything a character owns.
 
 * __Path:__ ``/char/AssetList.xml.aspx``
-* __Access mask:__ 2
 * __Cache timer:__ ca. 2 hours (XML cache), 6 hours (data cache)
+* __Access mask:__ 2
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_blueprints.md
+++ b/docs/xmlapi/character/char_blueprints.md
@@ -2,25 +2,15 @@
 Lists blueprints in characters inventory
 
 * __Path:__ ``/char/Blueprints.xml.aspx``
+* __Cache timer:__ 720 minutes
 * __Access mask:__ 2
-* __Cache timer:__ 720 minutes  
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_bookmarks.md
+++ b/docs/xmlapi/character/char_bookmarks.md
@@ -2,25 +2,15 @@
 Retrieve character Bookmarks.
 
 * __Path:__ ``/char/Bookmarks.xml.aspx``
-* __Access mask:__ 268435456
 * __Cache timer:__ 1 hour
+* __Access mask:__ 268435456
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_calendareventattendees.md
+++ b/docs/xmlapi/character/char_calendareventattendees.md
@@ -2,25 +2,15 @@
 Returns a list of all invited attendees for a given event.
 
 * __Path:__ ``/char/CalendarEventAttendees.xml.aspx``
-* __Access mask:__ 4
 * __Cache timer:__ 10 minutes
+* __Access mask:__ 4
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_charactersheet.md
+++ b/docs/xmlapi/character/char_charactersheet.md
@@ -2,25 +2,15 @@
 Character, Skills and roles information
 
 * __Path:__ ``/char/CharacterSheet.xml.aspx``
-* __Access mask:__ 8
 * __Cache timer:__ 60 minutes
+* __Access mask:__ 8
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_chatchannels.md
+++ b/docs/xmlapi/character/char_chatchannels.md
@@ -2,25 +2,15 @@
 Retrieve character Chat Channels.
 
 * __Path:__ ``/char/ChatChannels.xml.aspx``
-* __Access mask:__ 536870912
 * __Cache timer:__ 1 hour
+* __Access mask:__ 536870912
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_contactlist.md
+++ b/docs/xmlapi/character/char_contactlist.md
@@ -2,25 +2,15 @@
 Lists the character's personal, corporation, and alliance contacts.
 
 * __Path:__ ``/char/ContactList.xml.aspx``
+* __Cache timer:__ 15 minutes
 * __Access mask:__ 16
-* __Cache timer:__ 15 minutes  
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_contactnotifications.md
+++ b/docs/xmlapi/character/char_contactnotifications.md
@@ -2,25 +2,15 @@
 Lists the notifications received about having been added to someone's contact list.
 
 * __Path:__ ``/char/ContactNotifications.xml.aspx``
-* __Access mask:__ 32
 * __Cache timer:__ 30 minutes
+* __Access mask:__ 32
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_contractbids.md
+++ b/docs/xmlapi/character/char_contractbids.md
@@ -2,25 +2,15 @@
 Retrieve bids that have been placed on the characters auctions.
 
 * __Path:__ ``/char/ContractBids.xml.aspx``
+* __Cache timer:__ 15 minutes
 * __Access mask:__ 67108864
-* __Cache timer:__ 15 minutes  
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_contractitems.md
+++ b/docs/xmlapi/character/char_contractitems.md
@@ -2,25 +2,15 @@
 Lists Items and details of a particular contract.
 
 * __Path:__ ``/char/ContractItems.xml.aspx``
+* __Cache timer:__ 10 years
 * __Access mask:__ 67108864
-* __Cache timer:__ 10 years 
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_contracts.md
+++ b/docs/xmlapi/character/char_contracts.md
@@ -2,25 +2,15 @@
 Returns available contracts to character.
 
 * __Path:__ ``/char/Contracts.xml.aspx``
-* __Access mask:__ 67108864
 * __Cache timer:__ 60 minutes
+* __Access mask:__ 67108864
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_facwarstats.md
+++ b/docs/xmlapi/character/char_facwarstats.md
@@ -2,25 +2,15 @@
 Returns faction warfare information for characters enrolled in faction warfare.
 
 * __Path:__ ``/char/FacWarStats.xml.aspx``
-* __Access mask:__ 64
 * __Cache timer:__ 1 hour
+* __Access mask:__ 64
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_industryjobs.md
+++ b/docs/xmlapi/character/char_industryjobs.md
@@ -2,25 +2,15 @@
 Retrieve unfinished character industry jobs.
 
 * __Path:__ ``/char/IndustryJobs.xml.aspx``
-* __Access mask:__ 128
 * __Cache timer:__ 15 minutes
+* __Access mask:__ 128
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_industryjobshistory.md
+++ b/docs/xmlapi/character/char_industryjobshistory.md
@@ -2,25 +2,15 @@
 Retrieve finished character industry jobs.
 
 * __Path:__ ``/char/IndustryJobsHistory.xml.aspx``
-* __Access mask:__ 128
 * __Cache timer:__ 6 hours
+* __Access mask:__ 128
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_locations.md
+++ b/docs/xmlapi/character/char_locations.md
@@ -4,25 +4,15 @@ Retrieve location and name of specific items that belong to the character / corp
 retrieve the player-set name of containers and ships.
 
 * __Path:__ ``/char/Locations.xml.aspx``
+* __Cache timer:__ 1 hour
 * __Access mask:__ 134217728
-* __Cache timer:__ 1 hour  
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td>long</td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td>string</td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_mailbodies.md
+++ b/docs/xmlapi/character/char_mailbodies.md
@@ -2,25 +2,15 @@
 Returns the bodies of eve mail messages sent to the character.
 
 * __Path:__ ``/char/MailBodies.xml.aspx``
-* __Access mask:__ 512
 * __Cache timer:__ 10 years <sup style="color: red; font-weight: bold">(see notes below)</sup>
+* __Access mask:__ 512
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_mailinglists.md
+++ b/docs/xmlapi/character/char_mailinglists.md
@@ -2,25 +2,15 @@
 Returns the mailing list the character is a member of.
 
 * __Path:__ ``/char/mailinglists.xml.aspx``
-* __Access mask:__ 1024
 * __Cache timer:__ 6 hours
+* __Access mask:__ 1024
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_mailmessages.md
+++ b/docs/xmlapi/character/char_mailmessages.md
@@ -2,25 +2,15 @@
 Returns the header of eve mail messages sent to the character.
 
 * __Path:__ ``/char/MailMessages.xml.aspx``
-* __Access mask:__ 2048
 * __Cache timer:__ 15 minutes
+* __Access mask:__ 2048
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_marketorders.md
+++ b/docs/xmlapi/character/char_marketorders.md
@@ -2,25 +2,15 @@
 Retrieve character Market Orders.
 
 * __Path:__ ``/char/MarketOrders.xml.aspx``
-* __Access mask:__ 4096
 * __Cache timer:__ 1 hour
+* __Access mask:__ 4096
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_notifications.md
+++ b/docs/xmlapi/character/char_notifications.md
@@ -2,25 +2,15 @@
 Retrieve character notification headers.
 
 * __Path:__ ``/char/Notifications.xml.aspx``
-* __Access mask:__ 16384
 * __Cache timer:__ 30 minutes
+* __Access mask:__ 16384
 * __Parameters:__
 <table border="1">
     <tbody>
         <tr>
             <th>Argument</th>
             <th>Type</th>
-            <th>Meaning</th>
-        </tr>
-        <tr>
-            <td>keyID</td>
-            <td><strong>long</strong></td>
-            <td>API key ID</td>
-        </tr>
-        <tr>
-            <td>vCode</td>
-            <td><strong>char</strong></td>
-            <td>API verification code</td>
+            <th>Description</th>
         </tr>
         <tr>
             <td>characterID</td>

--- a/docs/xmlapi/character/char_notificationtexts.md
+++ b/docs/xmlapi/character/char_notificationtexts.md
@@ -2,25 +2,15 @@
 Retrieve character notification bodies.
 
 * __Path:__ ``/char/NotificationTexts.xml.aspx``
-* __Access mask:__ 32768
 * __Cache timer:__ 10 years <sup style="color: red; font-weight: bold">(see notes below)</sup>
+* __Access mask:__ 32768
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_planetarycolonies.md
+++ b/docs/xmlapi/character/char_planetarycolonies.md
@@ -2,25 +2,15 @@
 Retrieve planetary colonies owned by character.
 
 * __Path:__ ``/char/PlanetaryColonies.xml.aspx``
-* __Access mask:__ 2
 * __Cache timer:__ 60 minutes <sup style="color: red; font-weight: bold">(see notes below)</sup>
+* __Access mask:__ 2
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_planetarylinks.md
+++ b/docs/xmlapi/character/char_planetarylinks.md
@@ -2,25 +2,15 @@
 Retrieve planetary links for colonies owned by character.
 
 * __Path:__ ``/char/PlanetaryLinks.xml.aspx``
-* __Access mask:__ 2
 * __Cache timer:__ 60 minutes <sup style="color: red; font-weight: bold">(see notes below)</sup>
+* __Access mask:__ 2
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_planetarypins.md
+++ b/docs/xmlapi/character/char_planetarypins.md
@@ -2,25 +2,15 @@
 Retrieve planetary pins for colonies owned by character.
 
 * __Path:__ ``/char/PlanetaryPins.xml.aspx``
-* __Access mask:__ 2
 * __Cache timer:__ 60 minutes <sup style="color: red; font-weight: bold">(see notes below)</sup>
+* __Access mask:__ 2
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_planetaryroutes.md
+++ b/docs/xmlapi/character/char_planetaryroutes.md
@@ -2,25 +2,15 @@
 Retrieve planetary routes for colonies owned by character.
 
 * __Path:__ ``/char/PlanetaryRoutes.xml.aspx``
-* __Access mask:__ 2
 * __Cache timer:__ 60 minutes <sup style="color: red; font-weight: bold">(see notes below)</sup>
+* __Access mask:__ 2
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_research.md
+++ b/docs/xmlapi/character/char_research.md
@@ -2,25 +2,15 @@
 Retrieve character research.
 
 * __Path:__ ``/char/Research.xml.aspx``
+* __Cache timer:__ 15 minutes
 * __Access mask:__ 65536
-* __Cache timer:__ 15 minutes  
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_skillintraining.md
+++ b/docs/xmlapi/character/char_skillintraining.md
@@ -2,25 +2,15 @@
 Retrieve character skill in training.
 
 * __Path:__ ``/char/SkillInTraining.xml.aspx``
-* __Access mask:__ 131072
 * __Cache timer:__ 1 hour
+* __Access mask:__ 131072
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_skillqueue.md
+++ b/docs/xmlapi/character/char_skillqueue.md
@@ -2,25 +2,15 @@
 Retrieve character skill queue.
 
 * __Path:__ ``/char/SkillQueue.xml.aspx``
-* __Access mask:__ 262144
 * __Cache timer:__ 1 hour
+* __Access mask:__ 262144
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_standings.md
+++ b/docs/xmlapi/character/char_standings.md
@@ -2,26 +2,16 @@
 Retrieve character standings.
 
 * __Path:__ ``/char/Standings.xml.aspx``
-* __Access mask:__ 524288
 * __Cache timer:__ 3 hours
+* __Access mask:__ 524288
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
+                <th>Description</th>
             </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
-            <tr>
             <tr>
                 <td>characterID</td>
                 <td><strong>long</strong></td>

--- a/docs/xmlapi/character/char_upcomingcalendarevents.md
+++ b/docs/xmlapi/character/char_upcomingcalendarevents.md
@@ -2,25 +2,15 @@
 Retrieve character upcoming calendar events.
 
 * __Path:__ ``/char/UpcomingCalendarEvents.xml.aspx``
-* __Access mask:__ 1048576
 * __Cache timer:__ 60 minutes
+* __Access mask:__ 1048576
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>string</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_walletjournal.md
+++ b/docs/xmlapi/character/char_walletjournal.md
@@ -2,25 +2,15 @@
 Retrieve character wallet journal.
 
 * __Path:__ ``/char/WalletJournal.xml.aspx``
-* __Access mask:__ 2097152
 * __Cache timer:__ 30 minutes
+* __Access mask:__ 2097152
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>string</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/character/char_wallettransactions.md
+++ b/docs/xmlapi/character/char_wallettransactions.md
@@ -2,25 +2,15 @@
 Retrieve character wallet transactions.
 
 * __Path:__ ``/char/WalletTransactions.xml.aspx``
-* __Access mask:__ 4194304
 * __Cache timer:__ 30 minutes
+* __Access mask:__ 4194304
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>string</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/corporation/corp_accountbalance.md
+++ b/docs/xmlapi/corporation/corp_accountbalance.md
@@ -2,25 +2,15 @@
 Retrieve corporation account balances.
 
 * __Path:__ ``/corp/AccountBalance.xml.aspx``
+* __Cache timer:__ 15 minutes
 * __Access mask:__ 1
-* __Cache timer:__ 15 minutes  
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/corporation/corp_bookmarks.md
+++ b/docs/xmlapi/corporation/corp_bookmarks.md
@@ -2,28 +2,9 @@
 Retrieve corporation Bookmarks.
 
 * __Path:__ ``/corp/Bookmarks.xml.aspx``
-* __Access mask:__ 67108864
 * __Cache timer:__ 1 hour
-* __Parameters:__
-    <table border="1">
-        <tbody>
-            <tr>
-                <th>Argument</th>
-                <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            <tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
-            <tr>
-        </tbody>
-    </table>
+* __Access mask:__ 67108864
+* __Parameters:__ none
 
 ### Sample Response
 

--- a/docs/xmlapi/corporation/corp_corporationsheet.md
+++ b/docs/xmlapi/corporation/corp_corporationsheet.md
@@ -2,42 +2,15 @@
 Returns details for a specific corporation.
 
 * __Path:__ ``/corp/CorporationSheet.xml.aspx``
-* __Access mask:__ 8
 * __Cache timer:__ 5 hours 57 minutes
+* __Access mask:__ none or 8
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
-            </tr>
-            <tr>
-                <td>corporationID</td>
-                <td><strong>long</strong></td>
-                <td>ID of corporation</td>
-            </tr>
-        </tbody>
-    </table>
-
-    or for <a href="#no-key">limited access</a>
-
-    <table border="1">
-        <tbody>
-            <tr>
-                <th>Argument</th>
-                <th>Type</th>
-                <th>Meaning</th>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>corporationID</td>
@@ -98,29 +71,8 @@ Returns details for a specific corporation.
 </result>
 ```
 
-### No key
+### Sample response (public)
 Public details of any corporation can be retrieved without an API key.
-
-* __Parameters:__
-    <table border="1">
-        <tbody>
-            <tr>
-                <th>Argument</th>
-                <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>corporationID</td>
-                <td><strong>long</strong></td>
-                <td>ID of corporation</td>
-            </tr>
-        </tbody>
-    </table>
-
-Notes.
-If you pass both corporationID and the other parameters to the API server it will return the non-member version of the information just like you had only passed it corporationID.
-
-### Sample Response
 
 ```xml
 <result>

--- a/docs/xmlapi/corporation/corp_industryjobs.md
+++ b/docs/xmlapi/corporation/corp_industryjobs.md
@@ -2,28 +2,9 @@
 Retrieve unfinished corporation industry jobs.
 
 * __Path:__ ``/corp/IndustryJobs.xml.aspx``
-* __Access mask:__ 128
 * __Cache timer:__ 15 minutes
-* __Parameters:__
-    <table border="1">
-        <tbody>
-            <tr>
-                <th>Argument</th>
-                <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
-            </tr>
-        </tbody>
-    </table>
+* __Access mask:__ 128
+* __Parameters:__ none
 
 ### Sample Response
 

--- a/docs/xmlapi/corporation/corp_industryjobshistory.md
+++ b/docs/xmlapi/corporation/corp_industryjobshistory.md
@@ -2,28 +2,9 @@
 Retrieve finished corporation industry jobs.
 
 * __Path:__ ``/corp/IndustryJobsHistory.xml.aspx``
-* __Access mask:__ 128
 * __Cache timer:__ 6 hours
-* __Parameters:__
-    <table border="1">
-        <tbody>
-            <tr>
-                <th>Argument</th>
-                <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
-            </tr>
-        </tbody>
-    </table>
+* __Access mask:__ 128
+* __Parameters:__ none
 
 ### Sample Response
 

--- a/docs/xmlapi/corporation/corp_marketorders.md
+++ b/docs/xmlapi/corporation/corp_marketorders.md
@@ -1,25 +1,15 @@
 # MarketOrders
 
 * __Path:__ ``/corp/MarketOrders.xml.aspx``
-* __Access mask:__ 4096
 * __Cache timer:__ 1 hour (assumed from /char/MarketOrders.xml.aspx)
+* __Access mask:__ 4096
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>

--- a/docs/xmlapi/corporation/corp_membersecurity.md
+++ b/docs/xmlapi/corporation/corp_membersecurity.md
@@ -1,28 +1,9 @@
 # MemberSecurity
 
 * __Path:__ ``/corp/MemberSecurity.xml.aspx``
-* __Access mask:__ 512
 * __Cache timer:__ 57 minutes
-* __Parameters:__
-    <table border="1">
-        <tbody>
-            <tr>
-                <th>Argument</th>
-                <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
-            </tr>
-        </tbody>
-    </table>
+* __Access mask:__ 512
+* __Parameters:__ none
 
 ### Sample Response
 

--- a/docs/xmlapi/corporation/corp_membertracking.md
+++ b/docs/xmlapi/corporation/corp_membertracking.md
@@ -1,25 +1,15 @@
 # MemberTracking
 
 * __Path:__ ``/corp/MemberTracking.xml.aspx``
-* __Access mask:__ 2048 (MemberTrackingLimited) or 33554432 (MemberTrackingExtended)
 * __Cache timer:__ 5 hours 30 minutes
+* __Access mask:__ 2048 (MemberTrackingLimited) or 33554432 (MemberTrackingExtended)
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>extended</td>

--- a/docs/xmlapi/corporation/corp_standings.md
+++ b/docs/xmlapi/corporation/corp_standings.md
@@ -2,28 +2,9 @@
 Returns the standings that non-player entities have to the corporation.
 
 * __Path:__ ``/corp/Standings.xml.aspx``
-* __Access mask:__ 262144
 * __Cache timer:__ 3 hours 57 minutes
-* __Parameters:__
-    <table border="1">
-        <tbody>
-            <tr>
-                <th>Argument</th>
-                <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
-            </tr>
-        </tbody>
-    </table>
+* __Access mask:__ 262144
+* __Parameters:__ none
 
 ### Sample Response
 

--- a/docs/xmlapi/corporation/corp_starbasedetail.md
+++ b/docs/xmlapi/corporation/corp_starbasedetail.md
@@ -2,25 +2,15 @@
 Returns details for specified starbase.
 
 * __Path:__ ``/corp/StarbaseDetail.xml.aspx``
-* __Access mask:__ 131072
 * __Cache timer:__ 1 hour
+* __Access mask:__ 131072
 * __Parameters:__
      <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>itemID</td>

--- a/docs/xmlapi/corporation/corp_starbaselist.md
+++ b/docs/xmlapi/corporation/corp_starbaselist.md
@@ -2,28 +2,9 @@
 Returns list of corporation starbases.
 
 * __Path:__ ``/corp/StarbaseList.xml.aspx``
-* __Access mask:__ 524288
 * __Cache timer:__ 6 hours
-* __Parameters:__ 
-	<table border="1">
-		<tbody>
-            <tr>
-                <th>Argument</th>
-                <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char</strong></td>
-                <td>API verification code</td>
-            </tr>
-		</tbody>
-	</table>
+* __Access mask:__ 524288
+* __Parameters:__ none
 
 ### Sample Response
 ```xml

--- a/docs/xmlapi/corporation/corp_walletjournal.md
+++ b/docs/xmlapi/corporation/corp_walletjournal.md
@@ -2,25 +2,15 @@
 Retrieve corporation wallet journal.
 
 * __Path:__ ``/corp/WalletJournal.xml.aspx``
-* __Access mask:__ 1048576
 * __Cache timer:__ 30 minutes
+* __Access mask:__ 1048576
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>string</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>accountKey</td>

--- a/docs/xmlapi/corporation/corp_wallettransactions.md
+++ b/docs/xmlapi/corporation/corp_wallettransactions.md
@@ -2,25 +2,15 @@
 Retrieve corporation wallet transactions.
   
 * __Path:__ ``/corp/WalletTransactions.xml.aspx``
-* __Access mask:__ 2097152
 * __Cache timer:__ 30 minutes
+* __Access mask:__ 2097152
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID</td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>string</strong></td>
-                <td>API verification code</td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>accountKey</td>

--- a/docs/xmlapi/eve/eve_alliancelist.md
+++ b/docs/xmlapi/eve/eve_alliancelist.md
@@ -2,15 +2,15 @@
 Returns active Alliances in New Eden and their member Corporations.
 
 * __Path:__ ``/eve/AllianceList.xml.aspx``
-* __Access mask:__ None
 * __Cache timer:__ 60 minutes
+* __Access mask:__ none
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>version</td>

--- a/docs/xmlapi/eve/eve_characteraffiliation.md
+++ b/docs/xmlapi/eve/eve_characteraffiliation.md
@@ -1,15 +1,15 @@
 # CharacterAffiliation
 
 * __Path:__ ``/eve/CharacterAffiliation.xml.aspx ``
-* __Access mask:__ None
 * __Cache timer:__ 60 minutes
+* __Access mask:__ none
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>ids</td>

--- a/docs/xmlapi/eve/eve_characterid.md
+++ b/docs/xmlapi/eve/eve_characterid.md
@@ -1,15 +1,15 @@
 # CharacterID
 
 * __Path:__ ``/eve/CharacterID.xml.aspx ``
-* __Access mask:__ None
 * __Cache timer:__ 720 minutes
+* __Access mask:__ none
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>names</td>

--- a/docs/xmlapi/eve/eve_characterinfo.md
+++ b/docs/xmlapi/eve/eve_characterinfo.md
@@ -2,25 +2,15 @@
 Returns information about the character. Has three data sets it can return depending on access mask.
 
 * __Path:__ ``/eve/CharacterInfo.xml.aspx ``
-* __Access mask:__ 0 or 8388608 or 16777216
 * __Cache timer:__ 60 minutes
+* __Access mask:__ none or 8388608 or 16777216
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
-            </tr>
-            <tr>
-                <td>keyID</td>
-                <td><strong>long</strong></td>
-                <td>API key ID <em>(Optional)</em></td>
-            </tr>
-            <tr>
-                <td>vCode</td>
-                <td><strong>char(64)</strong></td>
-                <td>API verification code <em>(Optional)</em></td>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>characterID</td>
@@ -30,7 +20,7 @@ Returns information about the character. Has three data sets it can return depen
         </tbody>
     </table>
 
-### Sample Response (access mask 0)
+### Sample Response (no access mask)
 
 ```xml
 <eveapi version="2">

--- a/docs/xmlapi/eve/eve_charactername.md
+++ b/docs/xmlapi/eve/eve_charactername.md
@@ -2,15 +2,15 @@
 Returns the names for a comma-separated list of owner IDs for characters, corporations, alliances, and so on.
 
 * __Path:__ ``/eve/CharacterName.xml.aspx ``
-* __Access mask:__ None
 * __Cache timer:__ 30 days
+* __Access mask:__ none
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>ids</td>

--- a/docs/xmlapi/eve/eve_conquerablestationlist.md
+++ b/docs/xmlapi/eve/eve_conquerablestationlist.md
@@ -2,9 +2,9 @@
 Returns a list of conquerable stations in New Eden.
 
 * __Path:__ ``/eve/ConquerableStationList.xml.aspx``
-* __Access mask:__ none
 * __Cache timer:__ 1 hour
-* __Parameters:__ None, this function accepts no arguments.
+* __Access mask:__ none
+* __Parameters:__ none
 
 ### Sample Response
 

--- a/docs/xmlapi/eve/eve_errorlist.md
+++ b/docs/xmlapi/eve/eve_errorlist.md
@@ -2,9 +2,9 @@
 Returns a list of error codes and text that the API may return.
 
 * __Path:__ ``/eve/ErrorList.xml.aspx``
-* __Access mask:__ none
 * __Cache timer:__ 1 hour
-* __Parameters:__ None, this function accepts no arguments.
+* __Access mask:__ none
+* __Parameters:__ none
 
 ### Sample Response
 

--- a/docs/xmlapi/eve/eve_reftypes.md
+++ b/docs/xmlapi/eve/eve_reftypes.md
@@ -2,9 +2,9 @@
 Returns a list of transaction types used in the [Corporation - WalletJournal](../corporation/corp_walletjournal.md) & [Character - WalletJournal](../character/char_walletjournal.md).
 
 * __Path:__ ``/eve/RefTypes.xml.aspx``
-* __Access mask:__ none
 * __Cache timer:__ 24 hour
-* __Parameters:__ None, this function accepts no arguments.
+* __Access mask:__ none
+* __Parameters:__ none
 
 ### Sample Response
 

--- a/docs/xmlapi/eve/eve_typename.md
+++ b/docs/xmlapi/eve/eve_typename.md
@@ -2,15 +2,15 @@
 Returns the names associated with a sequence of typeIDs.
 
 * __Path:__ ``/eve/TypeName.xml.aspx ``
-* __Access mask:__ None
 * __Cache timer:__ 1 hour
+* __Access mask:__ none
 * __Parameters:__
     <table border="1">
         <tbody>
             <tr>
                 <th>Argument</th>
                 <th>Type</th>
-                <th>Meaning</th>
+                <th>Description</th>
             </tr>
             <tr>
                 <td>ids</td>

--- a/docs/xmlapi/intro.md
+++ b/docs/xmlapi/intro.md
@@ -11,10 +11,6 @@ If you would like to access private information you will need an API key and can
 * Base URL: [https://api.eveonline.com/](https://api.eveonline.com/)
 * API Keys: [https://community.eveonline.com/support/api-key](https://community.eveonline.com/support/api-key)
 
-It is highly recommended that you consider using an existing [library](https://wiki.eveonline.com/en/wiki/XML_API_Libraries) to make accessing the API easier.
-
-You can also find some examples for getting started with the API over [here](https://wiki.eveonline.com/en/wiki/XML_API_Getting_Started).
-
 ## Other Information
 ### Rate Limits
 - General Rate Limit: 30 requests per second

--- a/docs/xmlapi/intro.md
+++ b/docs/xmlapi/intro.md
@@ -6,7 +6,7 @@ As the XML API is an HTTP API you can access it by simply pointing your browser 
 
 The above will take you to the public character information for the specific character ID.
 
-If you would like to access private information you will need an API key and can then do it like so: `https://api.eveonline.com/corp/IndustryJobsHistory.xml.aspx?keyID={api_key_id_here}&vCode={api_verification_code_here}`
+If you would like to access private information you will need to authenticate using one of the available methods as described in [Authentication](authentication.md).
 
 * Base URL: [https://api.eveonline.com/](https://api.eveonline.com/)
 * API Keys: [https://community.eveonline.com/support/api-key](https://community.eveonline.com/support/api-key)

--- a/docs/xmlapi/map/map_facwarsystems.md
+++ b/docs/xmlapi/map/map_facwarsystems.md
@@ -1,10 +1,10 @@
 # FacWarSystems
+Returns a list of contestable solarsystems and the NPC faction currently occupying them. It should be noted that this file only returns a non-zero ID if the occupying faction is not the sovereign faction.
 
-* __Description:__ Returns a list of contestable solarsystems and the NPC faction currently occupying them. It should be noted that this file only returns a non-zero ID if the occupying faction is not the sovereign faction.
 * __Path:__ ``/map/FacWarSystems.xml.aspx``
-* __Access mask:__ none
 * __Cache timer:__ 1 hour
-* __Parameters:__ None, this function accepts no arguments.
+* __Access mask:__ none
+* __Parameters:__ none
 
 ### Sample Response
 

--- a/docs/xmlapi/map/map_jumps.md
+++ b/docs/xmlapi/map/map_jumps.md
@@ -1,11 +1,10 @@
 # Jumps
-Provides number of jumps into per solar system, doesn't include wormhole space. 
+Returns the number of jumps in solarsystems within the last hour, doesn't include wormhole space. Only solar system where jumps have been made are listed, so assume zero in case the system is not listed.
 
-* __Description:__ Returns the number of jumps in solarsystems within the last hour. Only solar system where jumps have been made are listed, so assume zero in case the system is not listed.
 * __Path:__ ``/map/Jumps.xml.aspx``
-* __Access mask:__ none
 * __Cache timer:__ 1 hour
-* __Parameters:__ None, this function accepts no arguments.
+* __Access mask:__ none
+* __Parameters:__ none
 
 ### Sample Response
 

--- a/docs/xmlapi/map/map_kills.md
+++ b/docs/xmlapi/map/map_kills.md
@@ -1,11 +1,10 @@
 # Kills
-Provides number of ship, pod and NPC kills per solar system, doesn't include wormhole space. 
+Provides number of ship, pod and NPC kills per solar system within the last hour, doesn't include wormhole space. Only solar system where kills have been made are listed, so assume zero in case the system is not listed.
 
-* __Description:__ Returns the number of kills in solarsystems within the last hour. Only solar system where kills have been made are listed, so assume zero in case the system is not listed.
 * __Path:__ ``/map/kills.xml.aspx``
-* __Access mask:__ none
 * __Cache timer:__ 1 hour
-* __Parameters:__ None, this function accepts no arguments.
+* __Access mask:__ none
+* __Parameters:__ none
 
 ### Sample Response
 

--- a/docs/xmlapi/map/map_sovereignty.md
+++ b/docs/xmlapi/map/map_sovereignty.md
@@ -2,9 +2,9 @@
 Provides Sovereignty / Ownership information for solar systems in New Eden excluding wormhole space.
   
 * __Path:__ ``/map/Sovereignty.xml.aspx``
-* __Access mask:__ none
 * __Cache timer:__ 1 hour
-* __Parameters:__ None, this function accepts no arguments.
+* __Access mask:__ none
+* __Parameters:__ none
 
 ### Sample Response
 

--- a/docs/xmlapi/server/serv_serverstatus.md
+++ b/docs/xmlapi/server/serv_serverstatus.md
@@ -2,9 +2,9 @@
 Provides status of the server up/down and the number of users logged onto the server.
 
 * __Path:__ ``/server/ServerStatus.xml.aspx``
-* __Access mask:__ none
 * __Cache timer:__ 3 minutes
-* __Parameters:__ None, this function accepts no arguments.
+* __Access mask:__ none
+* __Parameters:__ none
 
 ### Sample Response
 


### PR DESCRIPTION
I added useful content to the XML API authentication page, detailing use of both API keys and SSO access tokens. I also removed the keyID and vCode parameters from parameter lists of all endpoints, as authentication is now covered on a separate page, and made some minor edits on them for consistency.