### PR TITLE
Filtering between W-space and K-space by system ID

### DIFF
--- a/docs/crest/map/map_constellations.md
+++ b/docs/crest/map/map_constellations.md
@@ -33,6 +33,8 @@ The constellations resource allows an application to read constellations.
 ### Route
 ``/constellations/<constellationID:constellationIdType>/``
 
+Constellation IDs for K-space start above 20000000, and IDs for W-space start above 21000000.
+
 ### GET
 * Cache: 1 hour
 

--- a/docs/crest/map/map_regions.md
+++ b/docs/crest/map/map_regions.md
@@ -33,6 +33,8 @@ The regions resource allows an application to read regions.
 ### Route
 ``/regions/<regionID:regionIdType>/``
 
+Region IDs for K-space start above 10000000, and IDs for W-space start above 11000000.
+
 ### GET
 * Cache: 1 hour
 

--- a/docs/crest/map/map_solarsystems.md
+++ b/docs/crest/map/map_solarsystems.md
@@ -33,7 +33,7 @@ The solar systems resource allows an application to read solar systems.
 ### Route
 ``/solarsystems/<solarsystemID:solarsystemIdType>/``
 
-Ids that start with 31 are wormhole solar system, 30 are normal (K-Space) solar systems.
+System IDs for K-space start above 3000000, and IDs for W-space start above 31000000.
 
 ### GET
 * Cache: 1 hour


### PR DESCRIPTION
It's a useful piece of information which people often ask about, but system IDs are integers, not strings, and we shouldn't be encouraging people to treat them as such.
Same thing can also be done with region and constellation IDs.