### PR TITLE
updated imageserver url for tq

### DIFF
--- a/docs/imageserver/intro.md
+++ b/docs/imageserver/intro.md
@@ -7,50 +7,50 @@ If a given image is not found in the database, the service responds with a 302 M
 
 You are welcome to point your clients and applications directly at the image server and use it as a CDN. You do not need to cache the images and serve them yourself.
 
-The base URL for the image server is https://image.eveonline.com
+The base URL for the image server is https://imageserver.eveonline.com
 
 # Image Routes
 ## Alliance Images
 * URL Pattern: `/Alliance/{allianceID}_{width}.png`
 * Available Sizes: 32, 64, 128
 * Samples:
-    * [Band of Brothers](https://image.eveonline.com/Alliance/632866070_128.png)
-    * [GoonSwarm](https://image.eveonline.com/Alliance/824518128_32.png)
+    * [Band of Brothers](https://imageserver.eveonline.com/Alliance/632866070_128.png)
+    * [GoonSwarm](https://imageserver.eveonline.com/Alliance/824518128_32.png)
 
 ## Corporation Images
 * URL Pattern: `/Corporation/{corpID}_{width}.png`
 * Available Sizes: 32, 64, 128, 256
 * Samples:
-    * [EVE University](https://image.eveonline.com/Corporation/917701062_128.png)
-    * [Love Squad](https://image.eveonline.com/Corporation/98076155_256.png)
+    * [EVE University](https://imageserver.eveonline.com/Corporation/917701062_128.png)
+    * [Love Squad](https://imageserver.eveonline.com/Corporation/98076155_256.png)
 
 ## Character Images
 * URL Pattern: `/Character/{characterID}_{width}.jpg`
 * Available Sizes: 32, 64, 128, 256, 512, 1024
 * Samples:
-    * [Large Collidable Object](https://image.eveonline.com/Character/91072482_1024.jpg)
-    * [Ice Driller](https://image.eveonline.com/Character/1611454010_512.jpg)
+    * [Large Collidable Object](https://imageserver.eveonline.com/Character/91072482_1024.jpg)
+    * [Ice Driller](https://imageserver.eveonline.com/Character/1611454010_512.jpg)
 
 ## Faction Images
 * URL Pattern: `/Alliance/{factionID}_{width}.png`
 * Available Sizes: 32, 64, 128
 * Samples:
-    * [Gallente Federation](https://image.eveonline.com/Alliance/500004_128.png)
-    * [Amarr Empire](https://image.eveonline.com/Alliance/500003_64.png)
+    * [Gallente Federation](https://imageserver.eveonline.com/Alliance/500004_128.png)
+    * [Amarr Empire](https://imageserver.eveonline.com/Alliance/500003_64.png)
 
 ## Inventory Types
 * URL Pattern: `/Type/{typeID}_{width}.png`
 * Available Sizes: 32, 64
 * Samples:
-    * [Domination Stasis Webifier](https://image.eveonline.com/Type/14264_32.png)
-    * [Exotic Dancers](https://image.eveonline.com/Type/17765_64.png)
+    * [Domination Stasis Webifier](https://imageserver.eveonline.com/Type/14264_32.png)
+    * [Exotic Dancers](https://imageserver.eveonline.com/Type/17765_64.png)
 
 ## Ship and Drone Renders
 * URL Pattern: `/Render/{typeID}_{width}.png`
 * Available Sizes: 32, 64, 128, 256, 512
 * Samples:
-    * [Machariel](https://image.eveonline.com/Render/17738_512.png)
-    * [Firbolg](https://image.eveonline.com/Render/23059_128.png)
+    * [Machariel](https://imageserver.eveonline.com/Render/17738_512.png)
+    * [Firbolg](https://imageserver.eveonline.com/Render/23059_128.png)
 
 
 # Legacy Portraits

--- a/docs/reference/reference.md
+++ b/docs/reference/reference.md
@@ -4,7 +4,7 @@
 
 - Application Management: [https://developers.eveonline.com/](https://developers.eveonline.com/)
 - CREST: [https://crest-tq.eveonline.com/](https://crest-tq.eveonline.com/)
-- Image Server: [https://image.eveonline.com/](https://image.eveonline.com/)
+- Image Server: [https://imageserver.eveonline.com/](https://imageserver.eveonline.com/)
 - Login: [https://login.eveonline.com/](https://login.eveonline.com/)
 - XML API: [https://api.eveonline.com/](https://api.eveonline.com/)
 


### PR DESCRIPTION
[devblog](https://developers.eveonline.com/blog/article/image-server-cdn-changes/) on the changes.

no mention of test-server changes for images, so I left those references alone.