### PR TITLE
Resolve errors with URI

### DIFF
--- a/docs/crest/character/char_contacts.md
+++ b/docs/crest/character/char_contacts.md
@@ -102,22 +102,13 @@ Returns the Location of the newly created contact in the Location header (also w
 }
 ```
 
-## Contact
 ### Route
-``/characters/<characterID:characterIdType>/contact/<contactID:contactIdType>/``
-
-### GET
-* Cache: 5 minutes
-* Scope: `characterContactsRead`
-
-```
-    Not Implemented!
-```
+``/characters/<characterID:characterIdType>/contacts/<contactID:contactIdType>/``
 
 ### PUT
 * Scope: `characterContactsWrite`
 
-Used like adding, just set to the values you want to adjust.
+Adds or updates a contact.
 
 ```json
 {


### PR DESCRIPTION
URI was listed as /contact/ when it is /contacts/
Removed statement about "GET" since it does not exist in this context.