### PR TITLE
Change published attribute type to boolean

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -27,5 +27,6 @@ Regner "CCP FoxFour" Blok-Andersen
 Robert "Vincent Eneticum" Schuh
 Rowan "Louis Vitton" Matulis
 Ryan "Sable Blitzmann" Holmes
+Sharay "Remy Hart" Logan
 Stefan "redCube" Hojer
 Tine "mentos1386" Jozelj

--- a/docs/xmlapi/character/char_skills.md
+++ b/docs/xmlapi/character/char_skills.md
@@ -89,7 +89,7 @@ Retrieve skills portion of character sheet.
         <tr>
 	    <td></td>
             <td>published</td>
-            <td><strong>int</strong></td>
+            <td><strong>boolean</strong></td>
             <td>0 = unpublished, 1 = published</td>
         </tr>
     </tbody>


### PR DESCRIPTION
Although the value for this attribute is literally an integer, it is being used to represent a boolean condition (published, unpublished). For example, [Skill In Training](https://eveonline-third-party-documentation.readthedocs.io/en/latest/xmlapi/character/char_skillintraining.html) also has the attribute `skillInTraining` which is literally an integer but typed as a boolean.