### PR TITLE
Change Contracts forCorp attribute to boolean

### DIFF
--- a/docs/xmlapi/character/char_contracts.md
+++ b/docs/xmlapi/character/char_contracts.md
@@ -100,7 +100,7 @@ Returns available contracts to character.
         </tr>
         <tr>
             <td>forCorp</td>
-            <td>int</td>
+            <td>boolean</td>
             <td>1 if the contract was issued on behalf of the issuer's corporation, 0 otherwise</td>
         </tr>
         <tr>


### PR DESCRIPTION
Same as #218:

Although the value for this attribute is literally an integer, it is being used to represent a boolean condition (1 for corporation, 0 for character contract). For example, [Skill In Training](https://eveonline-third-party-documentation.readthedocs.io/en/latest/xmlapi/character/char_skillintraining.html) also has the attribute `skillInTraining` which is literally an integer but typed as a boolean.