### PR TITLE
	Add legacy API note to corp account balance characterID param

### DIFF
--- a/docs/xmlapi/corporation/corp_accountbalance.md
+++ b/docs/xmlapi/corporation/corp_accountbalance.md
@@ -15,7 +15,7 @@ Retrieve corporation account balances.
             <tr>
                 <td>characterID</td>
                 <td><strong>long</strong></td>
-                <td>ID of accessing character (must have junior accountant access or higher in the character's corporation)</td>
+                <td>ID of accessing character (must have junior accountant access or higher in the character's corporation). Only used with legacy API keys.</td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
This PR removes the `characterID` parameter from corporation account balance and replaces it with `none`. Since a corporation key can only belong to one character, I suspect this may have been a copy/paste error from character account balance. The endpoint returns the same data even if I query it with a bogus `characterID`, which leads me to believe `characterID` is not a parameter of this endpoint.
