### PR TITLE
Update toCorpOrAllianceID type for MailMessages endpoint

### DIFF
--- a/docs/xmlapi/character/char_mailmessages.md
+++ b/docs/xmlapi/character/char_mailmessages.md
@@ -68,7 +68,7 @@ Returns the header of eve mail messages sent to the character.
         </tr>
         <tr>
             <td>toCorpOrAllianceID</td>
-            <td>string</td>
+            <td>int</td>
             <td>The ID of a corporation/alliance that the message was sent to.</td>
         </tr>
         <tr>


### PR DESCRIPTION
This PR updates the type of the `toCorpOrAllianceID` attribute for the [`MailMessages `](https://eveonline-third-party-documentation.readthedocs.io/en/latest/xmlapi/character/char_mailmessages.html) endpoint.