### PR TITLE
Fix parameter name

### DIFF
--- a/docs/xmlapi/character/char_killmails.md
+++ b/docs/xmlapi/character/char_killmails.md
@@ -13,7 +13,7 @@ Retrieve a list of character kills and deaths.
                 <th>Description</th>
             </tr>
             <tr>
-                <td>characterID</td>
+                <td>userID</td>
                 <td><strong>long</strong></td>
                 <td>ID of character</td>
             </tr>


### PR DESCRIPTION
The response of the call without paramers or with `characterID` claims to require userID.