### PR TITLE
Pinned sphinx to use 1.5 because recommonmark and 1.6 were not mixing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=1.3.3
+sphinx==1.5.6
 sphinx-autobuild>=0.6.0
 sphinx_rtd_theme>=0.1.9
 recommonmark==0.4.0


### PR DESCRIPTION
I noticed that developing locally was not building because of the library recommonmark. After looking into it and finding this issue: https://github.com/sphinx-doc/sphinx/issues/3800 it seemed like recommonmark and sphinx 1.6 were not working well together. After using the latest 1.5 version (1.5.6) it seems to still build and work. Therefore I'm changing the requirements to specifically rely on this known working version of Sphinx.